### PR TITLE
Add settings panel with feature toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Currently includes:
 - **Source:** [GreasyFork link](https://greasyfork.org/scripts/516719)  
 - **Features:**  
   - Adds guide links to each crime  
-  - Quick-buy button for materials/enhancers  
+  - Quick-buy button for materials/enhancers
   - Crime chain counter
+  - In-page settings panel
 
 ---
 


### PR DESCRIPTION
## Summary
- add new persistent settings system
- implement `initSettingsPanel` with toggles and API key input
- gate feature hooks (guide links, quick-buy links, crime chain counter) behind settings
- document settings panel in README

## Testing
- `node -c 'Torn Crime 2.0 Helper.js'`

------
https://chatgpt.com/codex/tasks/task_e_6842b6d444d8832f88d20dafbd573f15